### PR TITLE
feat(security): add Keycloak auth and user management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,11 @@ services:
       # OAuth2 Configuration (using keycloak service name for internal communication)
       SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: http://keycloak:8080/realms/minibank
       SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: http://keycloak:8080/realms/minibank/protocol/openid-connect/certs
+      KEYCLOAK_BASE_URL: http://keycloak:8080
+      KEYCLOAK_REALM: minibank
+      KEYCLOAK_CLIENT_ID: minibank-api
+      KEYCLOAK_CLIENT_SECRET: minibank-secret
+      KEYCLOAK_ADMIN_REALM: master
 
       # Management/Actuator Configuration
 #      MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: health,info,metrics

--- a/src/main/kotlin/cz/ememsoft/minibank/api/AuthController.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/api/AuthController.kt
@@ -1,0 +1,50 @@
+package cz.ememsoft.minibank.api
+
+import cz.ememsoft.minibank.dto.auth.CreateUserRequestDto
+import cz.ememsoft.minibank.dto.auth.CreateUserResponseDto
+import cz.ememsoft.minibank.dto.auth.LoginRequestDto
+import cz.ememsoft.minibank.dto.auth.RefreshTokenRequestDto
+import cz.ememsoft.minibank.dto.auth.TokenResponseDto
+import cz.ememsoft.minibank.service.KeycloakAdminService
+import cz.ememsoft.minibank.service.KeycloakAuthService
+import jakarta.validation.Valid
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/api/auth")
+class AuthController(
+    private val keycloakAuthService: KeycloakAuthService,
+    private val keycloakAdminService: KeycloakAdminService,
+) {
+
+    @PostMapping("/login")
+    fun login(@Valid @RequestBody request: LoginRequestDto): Mono<TokenResponseDto> {
+        return keycloakAuthService.login(request.username, request.password)
+    }
+
+    @PostMapping("/refresh")
+    fun refresh(@Valid @RequestBody request: RefreshTokenRequestDto): Mono<TokenResponseDto> {
+        return keycloakAuthService.refresh(request.refreshToken)
+    }
+
+    @PostMapping("/register")
+    fun register(@Valid @RequestBody request: CreateUserRequestDto): Mono<CreateUserResponseDto> {
+        val sanitizedRequest = request.copy(roles = emptySet())
+        return keycloakAdminService.createUser(sanitizedRequest, defaultRoles = setOf(DEFAULT_ROLE))
+    }
+
+    @PostMapping("/users")
+    @PreAuthorize("hasRole('ADMIN')")
+    fun createUser(@Valid @RequestBody request: CreateUserRequestDto): Mono<CreateUserResponseDto> {
+        return keycloakAdminService.createUser(request)
+    }
+
+    companion object {
+        private const val DEFAULT_ROLE = "CUSTOMER"
+    }
+}

--- a/src/main/kotlin/cz/ememsoft/minibank/config/KeycloakConfig.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/config/KeycloakConfig.kt
@@ -1,0 +1,8 @@
+package cz.ememsoft.minibank.config
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(KeycloakProperties::class)
+class KeycloakConfig

--- a/src/main/kotlin/cz/ememsoft/minibank/config/KeycloakProperties.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/config/KeycloakProperties.kt
@@ -1,0 +1,12 @@
+package cz.ememsoft.minibank.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "keycloak")
+data class KeycloakProperties(
+    val baseUrl: String,
+    val realm: String,
+    val clientId: String,
+    val clientSecret: String,
+    val adminRealm: String = "master",
+)

--- a/src/main/kotlin/cz/ememsoft/minibank/config/SecurityConfig.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/config/SecurityConfig.kt
@@ -1,0 +1,66 @@
+package cz.ememsoft.minibank.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter
+import org.springframework.security.web.server.SecurityWebFilterChain
+
+@Configuration
+@EnableWebFluxSecurity
+@EnableReactiveMethodSecurity
+class SecurityConfig {
+
+    @Bean
+    fun securityWebFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
+        return http
+            .csrf { it.disable() }
+            .authorizeExchange { exchanges ->
+                exchanges
+                    .pathMatchers(
+                        "/api/auth/**",
+                        "/actuator/health",
+                        "/v3/api-docs/**",
+                        "/swagger-ui.html",
+                        "/swagger-ui/**",
+                    )
+                    .permitAll()
+                    .anyExchange()
+                    .authenticated()
+            }
+            .oauth2ResourceServer { resourceServer ->
+                resourceServer.jwt { jwtSpec ->
+                    jwtSpec.jwtAuthenticationConverter(jwtAuthenticationConverter())
+                }
+            }
+            .build()
+    }
+
+    @Bean
+    fun jwtAuthenticationConverter(): ReactiveJwtAuthenticationConverterAdapter {
+        val converter = JwtAuthenticationConverter()
+        converter.setJwtGrantedAuthoritiesConverter(realmRoleAuthoritiesConverter())
+        return ReactiveJwtAuthenticationConverterAdapter(converter)
+    }
+
+    private fun realmRoleAuthoritiesConverter(): Converter<Jwt, Collection<GrantedAuthority>> {
+        return Converter { jwt ->
+            val realmAccess = jwt.getClaim<Map<String, Any>>("realm_access")
+            val roles = realmAccess?.get("roles") as? Collection<*>
+            roles
+                ?.mapNotNull { role ->
+                    (role as? String)?.let { SimpleGrantedAuthority("ROLE_${it}") }
+                }
+                ?.toSet()
+                ?: emptySet()
+        }
+    }
+}

--- a/src/main/kotlin/cz/ememsoft/minibank/dto/auth/CreateUserRequestDto.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/dto/auth/CreateUserRequestDto.kt
@@ -1,0 +1,21 @@
+package cz.ememsoft.minibank.dto.auth
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * Request payload for creating a Keycloak user.
+ */
+data class CreateUserRequestDto(
+    @field:NotBlank(message = "Username must not be blank")
+    val username: String,
+    @field:NotBlank(message = "Password must not be blank")
+    val password: String,
+    @field:NotBlank(message = "First name must not be blank")
+    val firstName: String,
+    @field:NotBlank(message = "Last name must not be blank")
+    val lastName: String,
+    @field:Email(message = "Email must be valid")
+    val email: String,
+    val roles: Set<String>? = null,
+)

--- a/src/main/kotlin/cz/ememsoft/minibank/dto/auth/CreateUserResponseDto.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/dto/auth/CreateUserResponseDto.kt
@@ -1,0 +1,8 @@
+package cz.ememsoft.minibank.dto.auth
+
+/**
+ * Response payload for created user.
+ */
+data class CreateUserResponseDto(
+    val userId: String,
+)

--- a/src/main/kotlin/cz/ememsoft/minibank/dto/auth/LoginRequestDto.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/dto/auth/LoginRequestDto.kt
@@ -1,0 +1,13 @@
+package cz.ememsoft.minibank.dto.auth
+
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * Request payload for user login.
+ */
+data class LoginRequestDto(
+    @field:NotBlank(message = "Username must not be blank")
+    val username: String,
+    @field:NotBlank(message = "Password must not be blank")
+    val password: String,
+)

--- a/src/main/kotlin/cz/ememsoft/minibank/dto/auth/RefreshTokenRequestDto.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/dto/auth/RefreshTokenRequestDto.kt
@@ -1,0 +1,11 @@
+package cz.ememsoft.minibank.dto.auth
+
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * Request payload for refreshing an access token.
+ */
+data class RefreshTokenRequestDto(
+    @field:NotBlank(message = "Refresh token must not be blank")
+    val refreshToken: String,
+)

--- a/src/main/kotlin/cz/ememsoft/minibank/dto/auth/TokenResponseDto.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/dto/auth/TokenResponseDto.kt
@@ -1,0 +1,13 @@
+package cz.ememsoft.minibank.dto.auth
+
+/**
+ * Response payload for Keycloak token responses.
+ */
+data class TokenResponseDto(
+    val accessToken: String,
+    val refreshToken: String?,
+    val expiresIn: Long,
+    val refreshExpiresIn: Long?,
+    val tokenType: String,
+    val scope: String?,
+)

--- a/src/main/kotlin/cz/ememsoft/minibank/service/KeycloakAdminService.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/service/KeycloakAdminService.kt
@@ -1,0 +1,145 @@
+package cz.ememsoft.minibank.service
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import cz.ememsoft.minibank.config.KeycloakProperties
+import cz.ememsoft.minibank.dto.auth.CreateUserRequestDto
+import cz.ememsoft.minibank.dto.auth.CreateUserResponseDto
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+@Service
+class KeycloakAdminService(
+    private val keycloakProperties: KeycloakProperties,
+    private val webClientBuilder: WebClient.Builder,
+) {
+
+    fun createUser(request: CreateUserRequestDto, defaultRoles: Set<String> = emptySet()): Mono<CreateUserResponseDto> {
+        val rolesToAssign = request.roles?.takeIf { it.isNotEmpty() } ?: defaultRoles
+        return adminToken()
+            .flatMap { token ->
+                createUserWithToken(token, request)
+                    .flatMap { userId ->
+                        if (rolesToAssign.isEmpty()) {
+                            Mono.just(userId)
+                        } else {
+                            assignRealmRoles(token, userId, rolesToAssign).thenReturn(userId)
+                        }
+                    }
+            }
+            .map { CreateUserResponseDto(it) }
+    }
+
+    private fun createUserWithToken(token: String, request: CreateUserRequestDto): Mono<String> {
+        val payload = KeycloakUserRepresentation(
+            username = request.username,
+            enabled = true,
+            firstName = request.firstName,
+            lastName = request.lastName,
+            email = request.email,
+            emailVerified = true,
+            credentials = listOf(KeycloakCredentialRepresentation(request.password)),
+        )
+
+        return webClientBuilder.build()
+            .post()
+            .uri("${keycloakProperties.baseUrl}/admin/realms/${keycloakProperties.realm}/users")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(payload)
+            .exchangeToMono { response -> handleUserCreateResponse(response) }
+    }
+
+    private fun handleUserCreateResponse(response: ClientResponse): Mono<String> {
+        return if (response.statusCode().is2xxSuccessful) {
+            val location = response.headers().asHttpHeaders().location
+            val userId = location?.path?.substringAfterLast('/')
+            if (userId.isNullOrBlank()) {
+                response.bodyToMono(String::class.java)
+                    .defaultIfEmpty("No body")
+                    .flatMap { Mono.error(IllegalStateException("Missing user id in Keycloak response: $it")) }
+            } else {
+                Mono.just(userId)
+            }
+        } else {
+            response.bodyToMono(String::class.java)
+                .defaultIfEmpty("No body")
+                .flatMap { Mono.error(IllegalStateException("Failed to create Keycloak user: $it")) }
+        }
+    }
+
+    private fun assignRealmRoles(token: String, userId: String, roles: Set<String>): Mono<Void> {
+        return Flux.fromIterable(roles)
+            .flatMap { roleName ->
+                webClientBuilder.build()
+                    .get()
+                    .uri("${keycloakProperties.baseUrl}/admin/realms/${keycloakProperties.realm}/roles/$roleName")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                    .retrieve()
+                    .bodyToMono(KeycloakRoleRepresentation::class.java)
+            }
+            .collectList()
+            .flatMap { roleRepresentations ->
+                webClientBuilder.build()
+                    .post()
+                    .uri("${keycloakProperties.baseUrl}/admin/realms/${keycloakProperties.realm}/users/$userId/role-mappings/realm")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(roleRepresentations)
+                    .retrieve()
+                    .bodyToMono(Void::class.java)
+            }
+    }
+
+    private fun adminToken(): Mono<String> {
+        return webClientBuilder.build()
+            .post()
+            .uri("${keycloakProperties.baseUrl}/realms/${keycloakProperties.adminRealm}/protocol/openid-connect/token")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(
+                BodyInserters.fromFormData("grant_type", "password")
+                    .with("client_id", "admin-cli")
+                    .with("username", ADMIN_USERNAME)
+                    .with("password", ADMIN_PASSWORD),
+            )
+            .retrieve()
+            .bodyToMono(KeycloakTokenResponse::class.java)
+            .map { it.accessToken }
+    }
+
+    private data class KeycloakTokenResponse(
+        @JsonProperty("access_token")
+        val accessToken: String,
+    )
+
+    private data class KeycloakUserRepresentation(
+        val username: String,
+        val enabled: Boolean,
+        val firstName: String,
+        val lastName: String,
+        val email: String,
+        val emailVerified: Boolean,
+        val credentials: List<KeycloakCredentialRepresentation>,
+    )
+
+    private data class KeycloakCredentialRepresentation(
+        val value: String,
+        val type: String = "password",
+        val temporary: Boolean = false,
+    )
+
+    private data class KeycloakRoleRepresentation(
+        val id: String,
+        val name: String,
+    )
+
+    companion object {
+        const val ADMIN_USERNAME = "admin"
+        const val ADMIN_PASSWORD = "admin"
+    }
+}

--- a/src/main/kotlin/cz/ememsoft/minibank/service/KeycloakAuthService.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/service/KeycloakAuthService.kt
@@ -1,0 +1,75 @@
+package cz.ememsoft.minibank.service
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import cz.ememsoft.minibank.config.KeycloakProperties
+import cz.ememsoft.minibank.dto.auth.TokenResponseDto
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+@Service
+class KeycloakAuthService(
+    private val keycloakProperties: KeycloakProperties,
+    private val webClientBuilder: WebClient.Builder,
+) {
+
+    fun login(username: String, password: String): Mono<TokenResponseDto> {
+        return tokenRequest(
+            grantType = "password",
+            formCustomizer = BodyInserters.fromFormData("username", username)
+                .with("password", password),
+        )
+    }
+
+    fun refresh(refreshToken: String): Mono<TokenResponseDto> {
+        return tokenRequest(
+            grantType = "refresh_token",
+            formCustomizer = BodyInserters.fromFormData("refresh_token", refreshToken),
+        )
+    }
+
+    private fun tokenRequest(
+        grantType: String,
+        formCustomizer: BodyInserters.FormInserter<String>,
+    ): Mono<TokenResponseDto> {
+        return webClientBuilder.build()
+            .post()
+            .uri("${keycloakProperties.baseUrl}/realms/${keycloakProperties.realm}/protocol/openid-connect/token")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .body(
+                formCustomizer
+                    .with("grant_type", grantType)
+                    .with("client_id", keycloakProperties.clientId)
+                    .with("client_secret", keycloakProperties.clientSecret),
+            )
+            .retrieve()
+            .bodyToMono(KeycloakTokenResponse::class.java)
+            .map { response ->
+                TokenResponseDto(
+                    accessToken = response.accessToken,
+                    refreshToken = response.refreshToken,
+                    expiresIn = response.expiresIn,
+                    refreshExpiresIn = response.refreshExpiresIn,
+                    tokenType = response.tokenType,
+                    scope = response.scope,
+                )
+            }
+    }
+
+    private data class KeycloakTokenResponse(
+        @JsonProperty("access_token")
+        val accessToken: String,
+        @JsonProperty("refresh_token")
+        val refreshToken: String?,
+        @JsonProperty("expires_in")
+        val expiresIn: Long,
+        @JsonProperty("refresh_expires_in")
+        val refreshExpiresIn: Long?,
+        @JsonProperty("token_type")
+        val tokenType: String,
+        @JsonProperty("scope")
+        val scope: String?,
+    )
+}

--- a/src/main/kotlin/cz/ememsoft/minibank/service/SecurityService.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/service/SecurityService.kt
@@ -5,6 +5,7 @@ import cz.ememsoft.minibank.exception.ClientUnauthorizedException
 import cz.ememsoft.minibank.repository.ClientRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.security.core.context.ReactiveSecurityContextHolder
+import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 
@@ -23,10 +24,14 @@ class SecurityService(
      */
     fun getAuthenticatedClientId(): Mono<Long> {
         return ReactiveSecurityContextHolder.getContext()
-            .map { it.authentication?.principal as? Long }
-            .filter { it != null }
-            .cast(Long::class.java)
+            .mapNotNull { it.authentication?.principal as? Jwt }
+            .map { it.subject }
             .switchIfEmpty(Mono.error(ClientUnauthorizedException("No authenticated user found")))
+            .flatMap { keycloakUserId ->
+                clientRepository.findByKeycloakUserId(keycloakUserId)
+                    .map { it.id }
+                    .switchIfEmpty(Mono.error(ClientUnauthorizedException("Authenticated client not found")))
+            }
     }
 
     /**

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -37,6 +37,13 @@ spring:
         allow-core-thread-timeout: true
       thread-name-prefix: "DevAsyncExecutor-"
 
+keycloak:
+  base-url: http://localhost:8080
+  realm: minibank
+  client-id: minibank-api
+  client-secret: minibank-secret
+  admin-realm: master
+
 server:
   port: 8082
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,10 @@ spring:
         queue-capacity: 25    # Size of the queue for pending tasks
         allow-core-thread-timeout: true # Allow core threads to time out
       thread-name-prefix: "AsyncExecutor-" # Custom thread name prefix
+
+keycloak:
+  base-url: http://localhost:8080
+  realm: minibank
+  client-id: minibank-api
+  client-secret: minibank-secret
+  admin-realm: master

--- a/src/test/kotlin/cz/ememsoft/minibank/TestBase.kt
+++ b/src/test/kotlin/cz/ememsoft/minibank/TestBase.kt
@@ -60,6 +60,13 @@ abstract class TestBase {
             registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") {
                 "${keycloakContainer.authServerUrl}realms/minibank"
             }
+
+            val keycloakBaseUrl = keycloakContainer.authServerUrl.removeSuffix("/")
+            registry.add("keycloak.base-url") { keycloakBaseUrl }
+            registry.add("keycloak.realm") { "minibank" }
+            registry.add("keycloak.client-id") { "minibank-api" }
+            registry.add("keycloak.client-secret") { "minibank-secret" }
+            registry.add("keycloak.admin-realm") { "master" }
         }
     }
 }

--- a/src/test/kotlin/cz/ememsoft/minibank/integration/AuthControllerIntegrationTest.kt
+++ b/src/test/kotlin/cz/ememsoft/minibank/integration/AuthControllerIntegrationTest.kt
@@ -1,0 +1,83 @@
+package cz.ememsoft.minibank.integration
+
+import cz.ememsoft.minibank.TestBase
+import cz.ememsoft.minibank.dto.auth.CreateUserRequestDto
+import cz.ememsoft.minibank.dto.auth.CreateUserResponseDto
+import cz.ememsoft.minibank.dto.auth.LoginRequestDto
+import cz.ememsoft.minibank.dto.auth.RefreshTokenRequestDto
+import cz.ememsoft.minibank.dto.auth.TokenResponseDto
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.util.UUID
+
+@AutoConfigureWebTestClient
+class AuthControllerIntegrationTest : TestBase() {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @Test
+    fun `login and refresh should return tokens`() {
+        val loginResponse = webTestClient.post()
+            .uri("/api/auth/login")
+            .bodyValue(LoginRequestDto("admin", "admin"))
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(TokenResponseDto::class.java)
+            .returnResult()
+            .responseBody!!
+
+        val refreshToken = loginResponse.refreshToken
+        require(!refreshToken.isNullOrBlank()) { "Expected refresh token" }
+
+        webTestClient.post()
+            .uri("/api/auth/refresh")
+            .bodyValue(RefreshTokenRequestDto(refreshToken))
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(TokenResponseDto::class.java)
+            .consumeWith { result ->
+                val refreshed = result.responseBody!!
+                kotlin.test.assertTrue(refreshed.accessToken.isNotBlank())
+            }
+    }
+
+    @Test
+    fun `register should create user and allow login`() {
+        val uniqueId = UUID.randomUUID().toString().substring(0, 8)
+        val username = "user-$uniqueId"
+        val password = "Pass-$uniqueId!"
+
+        val createResponse = webTestClient.post()
+            .uri("/api/auth/register")
+            .bodyValue(
+                CreateUserRequestDto(
+                    username = username,
+                    password = password,
+                    firstName = "Test",
+                    lastName = "User",
+                    email = "$username@minibank.test",
+                )
+            )
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(CreateUserResponseDto::class.java)
+            .returnResult()
+            .responseBody!!
+
+        kotlin.test.assertTrue(createResponse.userId.isNotBlank())
+
+        webTestClient.post()
+            .uri("/api/auth/login")
+            .bodyValue(LoginRequestDto(username, password))
+            .exchange()
+            .expectStatus().isOk
+            .expectBody(TokenResponseDto::class.java)
+            .consumeWith { result ->
+                val tokenResponse = result.responseBody!!
+                kotlin.test.assertTrue(tokenResponse.accessToken.isNotBlank())
+            }
+    }
+}

--- a/src/test/kotlin/cz/ememsoft/minibank/service/KeycloakAdminServiceTest.kt
+++ b/src/test/kotlin/cz/ememsoft/minibank/service/KeycloakAdminServiceTest.kt
@@ -1,0 +1,86 @@
+package cz.ememsoft.minibank.service
+
+import cz.ememsoft.minibank.config.KeycloakProperties
+import cz.ememsoft.minibank.dto.auth.CreateUserRequestDto
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.buffer.DefaultDataBufferFactory
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.util.concurrent.CopyOnWriteArrayList
+
+class KeycloakAdminServiceTest {
+
+    private val keycloakProperties = KeycloakProperties(
+        baseUrl = "http://localhost:8080",
+        realm = "minibank",
+        clientId = "minibank-api",
+        clientSecret = "minibank-secret",
+    )
+
+    @Test
+    fun `createUser should return id and assign roles`() {
+        val requests = CopyOnWriteArrayList<ClientRequest>()
+        val exchangeFunction = ExchangeFunction { request ->
+            requests.add(request)
+            val path = request.url().path
+            val method = request.method()
+            when {
+                path.endsWith("/protocol/openid-connect/token") -> {
+                    Mono.just(jsonResponse(HttpStatus.OK, "{\"access_token\":\"admin-token\"}"))
+                }
+                path.endsWith("/admin/realms/minibank/users") && method.name() == "POST" -> {
+                    Mono.just(
+                        ClientResponse.create(HttpStatus.CREATED)
+                            .header(HttpHeaders.LOCATION, "http://localhost:8080/admin/realms/minibank/users/user-123")
+                            .build()
+                    )
+                }
+                path.endsWith("/admin/realms/minibank/roles/CUSTOMER") -> {
+                    Mono.just(jsonResponse(HttpStatus.OK, "{\"id\":\"role-1\",\"name\":\"CUSTOMER\"}"))
+                }
+                path.endsWith("/admin/realms/minibank/users/user-123/role-mappings/realm") -> {
+                    Mono.just(ClientResponse.create(HttpStatus.NO_CONTENT).build())
+                }
+                else -> Mono.just(jsonResponse(HttpStatus.INTERNAL_SERVER_ERROR, "{}"))
+            }
+        }
+
+        val service = KeycloakAdminService(keycloakProperties, WebClient.builder().exchangeFunction(exchangeFunction))
+        val request = CreateUserRequestDto(
+            username = "new-user",
+            password = "secret",
+            firstName = "New",
+            lastName = "User",
+            email = "new.user@example.com",
+            roles = setOf("CUSTOMER"),
+        )
+
+        StepVerifier.create(service.createUser(request))
+            .assertNext { response ->
+                kotlin.test.assertEquals("user-123", response.userId)
+            }
+            .verifyComplete()
+
+        val calledPaths = requests.map { it.url().path }
+        kotlin.test.assertTrue(calledPaths.any { it.endsWith("/protocol/openid-connect/token") })
+        kotlin.test.assertTrue(calledPaths.any { it.endsWith("/admin/realms/minibank/users") })
+        kotlin.test.assertTrue(calledPaths.any { it.endsWith("/admin/realms/minibank/roles/CUSTOMER") })
+        kotlin.test.assertTrue(calledPaths.any { it.endsWith("/admin/realms/minibank/users/user-123/role-mappings/realm") })
+    }
+
+    private fun jsonResponse(status: HttpStatus, body: String): ClientResponse {
+        val buffer = DefaultDataBufferFactory().wrap(body.toByteArray())
+        return ClientResponse.create(status)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(Flux.just(buffer))
+            .build()
+    }
+}

--- a/src/test/kotlin/cz/ememsoft/minibank/service/KeycloakAuthServiceTest.kt
+++ b/src/test/kotlin/cz/ememsoft/minibank/service/KeycloakAuthServiceTest.kt
@@ -1,0 +1,96 @@
+package cz.ememsoft.minibank.service
+
+import cz.ememsoft.minibank.config.KeycloakProperties
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.buffer.DefaultDataBufferFactory
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class KeycloakAuthServiceTest {
+
+    private val keycloakProperties = KeycloakProperties(
+        baseUrl = "http://localhost:8080",
+        realm = "minibank",
+        clientId = "minibank-api",
+        clientSecret = "minibank-secret",
+    )
+
+    @Test
+    fun `login should map token response`() {
+        val exchangeFunction = tokenExchangeFunction(
+            """
+            {
+              "access_token": "access-123",
+              "refresh_token": "refresh-456",
+              "expires_in": 300,
+              "refresh_expires_in": 600,
+              "token_type": "Bearer",
+              "scope": "openid profile"
+            }
+            """.trimIndent()
+        )
+        val service = KeycloakAuthService(keycloakProperties, WebClient.builder().exchangeFunction(exchangeFunction))
+
+        StepVerifier.create(service.login("user", "password"))
+            .assertNext { response ->
+                kotlin.test.assertEquals("access-123", response.accessToken)
+                kotlin.test.assertEquals("refresh-456", response.refreshToken)
+                kotlin.test.assertEquals(300, response.expiresIn)
+                kotlin.test.assertEquals(600, response.refreshExpiresIn)
+                kotlin.test.assertEquals("Bearer", response.tokenType)
+                kotlin.test.assertEquals("openid profile", response.scope)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `refresh should map token response`() {
+        val exchangeFunction = tokenExchangeFunction(
+            """
+            {
+              "access_token": "access-789",
+              "refresh_token": "refresh-999",
+              "expires_in": 120,
+              "refresh_expires_in": 480,
+              "token_type": "Bearer",
+              "scope": "openid"
+            }
+            """.trimIndent()
+        )
+        val service = KeycloakAuthService(keycloakProperties, WebClient.builder().exchangeFunction(exchangeFunction))
+
+        StepVerifier.create(service.refresh("refresh-999"))
+            .assertNext { response ->
+                kotlin.test.assertEquals("access-789", response.accessToken)
+                kotlin.test.assertEquals("refresh-999", response.refreshToken)
+                kotlin.test.assertEquals(120, response.expiresIn)
+                kotlin.test.assertEquals(480, response.refreshExpiresIn)
+                kotlin.test.assertEquals("Bearer", response.tokenType)
+                kotlin.test.assertEquals("openid", response.scope)
+            }
+            .verifyComplete()
+    }
+
+    private fun tokenExchangeFunction(jsonBody: String): ExchangeFunction {
+        return ExchangeFunction { request: ClientRequest ->
+            val response = jsonResponse(HttpStatus.OK, jsonBody)
+            Mono.just(response)
+        }
+    }
+
+    private fun jsonResponse(status: HttpStatus, body: String): ClientResponse {
+        val buffer = DefaultDataBufferFactory().wrap(body.toByteArray())
+        return ClientResponse.create(status)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(Flux.just(buffer))
+            .build()
+    }
+}


### PR DESCRIPTION
### Motivation
- Enable Keycloak as the authentication and authorization provider and expose REST endpoints for login, token refresh and user management.
- Protect the API surface as an OAuth2 resource server and map Keycloak realm roles to Spring `ROLE_*` authorities for method-level security.
- Provide programmatic Keycloak admin flows to create users and assign realm roles for application-managed registration and admin operations.
- Add comprehensive automated tests (unit + integration scaffolding) to validate auth/admin service behavior and end-to-end flows.

### Description
- Added Keycloak wiring and configuration objects (`KeycloakProperties`, `KeycloakConfig`) and added Keycloak settings to `application.yml`, `application-dev.yaml` and `docker-compose.yml`.
- Implemented security configuration (`SecurityConfig`) to enable WebFlux OAuth2 resource server and convert Keycloak realm roles into Spring authorities.
- Implemented auth surface: `KeycloakAuthService` (login/refresh), `KeycloakAdminService` (create user, assign roles), `AuthController` with endpoints `POST /api/auth/login`, `/api/auth/refresh`, `/api/auth/register` and admin-only `POST /api/auth/users`, plus DTOs for requests/responses.
- Updated `SecurityService` to extract JWT `sub` from the security context and resolve the internal client id via `clientRepository.findByKeycloakUserId(...)`, and added unit tests and integration test scaffolding (`TestBase`, `KeycloakAuthServiceTest`, `KeycloakAdminServiceTest`, `AuthControllerIntegrationTest`).

### Testing
- Added unit tests: `KeycloakAuthServiceTest` and `KeycloakAdminServiceTest` to validate token mapping and admin request flows, and integration scaffolding `AuthControllerIntegrationTest` for end-to-end scenarios using Testcontainers Keycloak.
- Attempted to run the full test suite with `./mvnw test` in this environment, but the Maven wrapper failed to download dependencies due to a network error (`Network is unreachable`).
- Because of the network restriction the automated test run did not complete here, but the new unit tests are self-contained and mock external HTTP calls and are expected to pass in CI.
- Integration tests require Testcontainers and a reachable network (Keycloak/Postgres) and should be exercised in CI where containers and network egress are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69638f916454832c94d5ceebc1f43e4a)