### PR TITLE
fix: avoid double-marking failed transactions and start Testcontainers before property resolution

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Run tests
+        run: ./mvnw -B test

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,13 @@
             <version>${mockito-kotlin.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- Kotlin test assertions -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- =================================================================== -->

--- a/src/main/kotlin/cz/ememsoft/minibank/service/SecurityService.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/service/SecurityService.kt
@@ -24,8 +24,7 @@ class SecurityService(
      */
     fun getAuthenticatedClientId(): Mono<Long> {
         return ReactiveSecurityContextHolder.getContext()
-            .mapNotNull { it.authentication?.principal as? Jwt }
-            .map { it.subject }
+            .flatMap { Mono.justOrEmpty((it.authentication?.principal as? Jwt)?.subject) }
             .switchIfEmpty(Mono.error(ClientUnauthorizedException("No authenticated user found")))
             .flatMap { keycloakUserId ->
                 clientRepository.findByKeycloakUserId(keycloakUserId)

--- a/src/main/kotlin/cz/ememsoft/minibank/service/TransactionServiceImpl.kt
+++ b/src/main/kotlin/cz/ememsoft/minibank/service/TransactionServiceImpl.kt
@@ -169,12 +169,9 @@ class TransactionServiceImpl(
             .flatMap { pendingTransaction: TransactionEntity ->
                 completeTransaction(pendingTransaction, sourceAccount, targetAccount, request.amount)
                     .onErrorResume { error ->
-                        // If completing the transaction fails, mark it as failed and re-throw
+                        // If completing the transaction fails, re-throw
                         logger.error(error) { "Transaction ${pendingTransaction.id} failed during completion" }
-                        transactionProcessor.failTransaction(
-                            pendingTransaction,
-                            error.message ?: "Transaction completion failed"
-                        ).then(Mono.error(error))
+                        Mono.error(error)
                     }
             }
             .map { completedTransaction ->

--- a/src/test/kotlin/cz/ememsoft/minibank/TestBase.kt
+++ b/src/test/kotlin/cz/ememsoft/minibank/TestBase.kt
@@ -32,7 +32,7 @@ abstract class TestBase {
 
         @Container
         @JvmStatic
-        val keycloakContainer: KeycloakContainer = KeycloakContainer("quay.io/keycloak/keycloak:latest")
+        val keycloakContainer: KeycloakContainer = KeycloakContainer("quay.io/keycloak/keycloak:25.0.6")
             .withRealmImportFile("config/keycloak/minibank-realm.json")
             .withReuse(true)
 
@@ -43,6 +43,12 @@ abstract class TestBase {
         @JvmStatic
         @DynamicPropertySource
         fun configureProperties(registry: DynamicPropertyRegistry) {
+            if (!postgreSQLContainer.isRunning) {
+                postgreSQLContainer.start()
+            }
+            if (!keycloakContainer.isRunning) {
+                keycloakContainer.start()
+            }
             // PostgreSQL properties
             registry.add("spring.r2dbc.url") {
                 "r2dbc:postgresql://${postgreSQLContainer.host}:${postgreSQLContainer.firstMappedPort}/${postgreSQLContainer.databaseName}"

--- a/src/test/kotlin/cz/ememsoft/minibank/service/TransactionServiceTest.kt
+++ b/src/test/kotlin/cz/ememsoft/minibank/service/TransactionServiceTest.kt
@@ -185,6 +185,8 @@ class TransactionServiceTest {
             .thenReturn(Mono.just(pendingTransaction))
         whenever(transactionProcessor.updateAccountBalances(eq(sourceAccount), eq(targetAccount), any()))
             .thenReturn(Mono.error(completionError))
+        whenever(transactionProcessor.completeTransaction(pendingTransaction))
+            .thenReturn(Mono.just(completedTransaction))
         whenever(transactionProcessor.failTransaction(eq(pendingTransaction), any()))
             .thenReturn(Mono.just(pendingTransaction.withStatus(TransactionStatusEnum.FAILED)))
 


### PR DESCRIPTION
### Motivation
- Prevent transactions from being marked failed twice which led to duplicate `failTransaction` interactions and Mockito verification failures.  
- Avoid accessing Testcontainers mapped ports before containers are started, which caused `Mapped port can only be obtained after the container is started` errors during integration test startup.  
- Stabilize integration tests that depend on Keycloak and PostgreSQL Testcontainers.  

### Description
- Remove redundant failure-path handling in `processValidatedTransaction` so completion errors are re-thrown instead of calling `transactionProcessor.failTransaction` twice.  
- Ensure Testcontainers are explicitly started in `TestBase.configureProperties` before resolving dynamic properties that use `firstMappedPort` or `authServerUrl`.  
- Pin the Keycloak testcontainer image to `quay.io/keycloak/keycloak:25.0.6` in `TestBase.kt`.  
- Add a Mockito stub in `TransactionServiceTest` for `transactionProcessor.completeTransaction(pendingTransaction)` to make the failure-path test deterministic.  

### Testing
- The prior CI run (before these fixes) executed 55 tests and reported 1 test failure and 4 integration errors related to Keycloak container startup and a duplicate mock interaction.  
- No automated tests were re-run as part of this change.  
- Unit test updates include stubbing `completeTransaction` to address the previous Mockito "Wanted but not invoked" failure.  
- Integration startup errors were addressed by starting containers before property resolution and pinning the Keycloak image to reduce flakiness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696397519fc8832c816ca04e0245b286)